### PR TITLE
Fixed bugs in  fmi1.c (model exchange -> init) and Resource/model.c

### DIFF
--- a/Resource/model.c
+++ b/Resource/model.c
@@ -35,6 +35,7 @@ void calculateValues(ModelInstance *comp) {
     } else if (strncmp(comp->resourceLocation, scheme2, strlen(scheme2)) == 0) {
         path = malloc(strlen(comp->resourceLocation) + strlen(resourcePath) + 1);
         strcpy(path, &comp->resourceLocation[strlen(scheme2) - 1]);
+	strcat(path, resourcePath);
     } else {
         logError(comp, "The resourceLocation must start with \"file:/\" or \"file:///\"");
         return;

--- a/src/fmi1.c
+++ b/src/fmi1.c
@@ -429,8 +429,7 @@ fmiComponent fmiInstantiateSlave(fmiString  instanceName, fmiString GUID,
 }
 
 fmiStatus fmiInitializeSlave(fmiComponent c, fmiReal tStart, fmiBoolean StopTimeDefined, fmiReal tStop) {
-    init(c);
-    return fmiOK;
+    return init(c);
 }
 
 fmiStatus fmiTerminateSlave(fmiComponent c) {
@@ -555,7 +554,15 @@ fmiComponent fmiInstantiateModel(fmiString instanceName, fmiString GUID,  fmiCal
 }
 
 fmiStatus fmiInitialize(fmiComponent c, fmiBoolean toleranceControlled, fmiReal relativeTolerance, fmiEventInfo* eventInfo) {
-    return init(c);
+    ModelInstance* comp = (ModelInstance *)c;
+    fmiStatus status = init(c);
+    eventInfo->iterationConverged  = fmiTrue;
+    eventInfo->stateValueReferencesChanged = fmiFalse;
+    eventInfo->stateValuesChanged = fmiFalse;
+    eventInfo->terminateSimulation = fmiFalse;
+    eventInfo->upcomingTimeEvent = comp->nextEventTimeDefined;
+    eventInfo->nextEventTime = comp->nextEventTime;
+    return status;
 }
 
 fmiStatus fmiSetTime(fmiComponent c, fmiReal time) {


### PR DESCRIPTION
Please see commit description for more details. These bugs were causing the Resource example and Stairs (model exchange) example to fail in some cases (tested with fmusdk and QTronic Silver)